### PR TITLE
Allows to use call extension without a block

### DIFF
--- a/lib/signal/extensions/call.rb
+++ b/lib/signal/extensions/call.rb
@@ -13,7 +13,7 @@ module Signal
       module ClassMethods
         def call(*args, &block)
           new(*args).tap do |instance|
-            yield(instance)
+            yield(instance) if block_given?
             instance.call
           end
         end

--- a/spec/signal/call_spec.rb
+++ b/spec/signal/call_spec.rb
@@ -4,7 +4,7 @@ describe Signal::Extensions::Call do
   let(:callable) { Callable.new }
 
   it 'initializes observable with arguments' do
-    observable = ObservableWithCall.call(1, 2, 3) {}
+    observable = ObservableWithCall.call(1, 2, 3)
     expect(observable.args).to eq([1, 2, 3])
   end
 


### PR DESCRIPTION
This allows to use the call signature without a explicit block, i.e.:

    service = Service.call(...)
    service.on(:failure) { ... }